### PR TITLE
Fix issue with ref forwarding

### DIFF
--- a/BoilerplateApp/src/TextField.tsx
+++ b/BoilerplateApp/src/TextField.tsx
@@ -1,4 +1,4 @@
-import React, { FC, RefObject } from "react"
+import React, { forwardRef, ForwardRefRenderFunction } from "react"
 import { StyleSheet, View, Text, TextInput, TextInputProps } from "react-native"
 
 import FieldErrors from "./FieldErrors"
@@ -11,18 +11,12 @@ interface TextFieldProps extends TextInputProps {
   value: string
   updateValue: (value: string) => void
   noMarginBottom?: boolean
-  ref?: RefObject<TextInput>
 }
 
-const TextField: FC<TextFieldProps> = ({
-  label,
-  errors,
-  value,
-  updateValue,
-  noMarginBottom,
+const TextField: ForwardRefRenderFunction<TextInput, TextFieldProps> = (
+  { label, errors, value, updateValue, noMarginBottom, ...props },
   ref,
-  ...props
-}) => {
+) => {
   const inputContainerStyle = {
     ...style.inputContainer,
     ...(noMarginBottom && { marginBottom: 0 }),
@@ -55,4 +49,4 @@ const style = StyleSheet.create({
   },
 })
 
-export default TextField
+export default forwardRef(TextField)

--- a/BoilerplateApp/src/styles/forms.ts
+++ b/BoilerplateApp/src/styles/forms.ts
@@ -11,8 +11,7 @@ export const input: Record<Input, TextStyle> = {
     ...Typography.regular.x30,
     lineHeight: 0,
     padding: Sizing.x20,
-    borderColor: Colors.neutral.s300,
-    borderWidth: Outlines.borderWidth.hairline,
+    backgroundColor: Colors.neutral.s100,
     borderRadius: Outlines.borderRadius.small,
   },
 }


### PR DESCRIPTION
Why: we are currently forward a ref through TextField into TextInput, which
requires us to use forwardRef from React.

More info: https://github.com/reactjs.org/docs/forwarding-refs.html

The ref enables us to go to the next TextInput on the SignIn screen by tapping
"Next" on the keyboard.

A future commit will add this functionality to SignUp as well.

<img src="http://g.recordit.co/ftTyiNKqhe.gif" />