### PR TITLE
Update readme to include license and contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to React Native Liftoff
+
+We love pull requests from everyone. By participating in this project, you
+agree to abide by the thoughtbot [code of conduct].
+
+[code of conduct]: https://thoughtbot.com/open-source-code-of-conduct
+
+Here are some ways *you* can contribute:
+
+* by reporting bugs
+* by suggesting new features
+* by writing or editing documentation
+* by writing specifications
+* by writing code ( **no patch is too small** : fix typos, add comments, etc. )
+* by refactoring code
+* by closing [issues][]
+* by reviewing patches
+
+[issues]: https://github.com/thoughtbot/react-native-liftoff/issue
+
+## Submitting an Issue
+
+* We use the [GitHub issue tracker][issues] to track bugs and features.
+* Before submitting a bug report or feature request, check to make sure it hasn't
+  already been submitted.
+* When submitting a bug report, please include a [reproduction script] and any
+  other details that may be necessary to reproduce the bug, including your gem
+  version, Ruby version, and operating system.
+
+## Cleaning up issues
+
+* Issues that have no response from the submitter will be closed after 30 days.
+* Issues will be closed once they're assumed to be fixed or answered. If the
+  maintainer is wrong, it can be opened again.
+* If your issue is closed by mistake, please understand and explain the issue.
+  We will happily reopen the issue.
+
+## Submitting a Pull Request
+
+1. [Fork][fork] the [official repository][repo].
+1. [Create a topic branch.][branch]
+1. Implement your feature or bug fix.
+1. Add, commit, and push your changes.
+1. [Submit a pull request.][pr]
+
+[repo]: https://github.com/thoughtbot/react-native-liftoff/tree/master
+[fork]: https://help.github.com/articles/fork-a-repo/
+[branch]: https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/
+[pr]: https://help.github.com/articles/using-pull-requests/
+[reproduction script]: https://github.com/thoughtbot/react-native-liftoff/blob/master/.github/REPRODUCTION_SCRIPT.rb
+
+Inspired by https://github.com/middleman/middleman-heroku/blob/master/CONTRIBUTING.md

--- a/readme.md
+++ b/readme.md
@@ -1,13 +1,81 @@
-# liftoff CLI
+# React Native Liftoff 🚀
 
-A CLI for starting up React Native apps fast.
+A CLI for starting up React Native apps, fast.
 
-## Installation
+Installation
+------------
 
 `yarn global add liftoff-cli`
+
 or
+
 `npm -g install liftoff-cli`
 
-## Usage
+Usage
+-----
 
 `liftoff new MyGreatApp`
+
+Whats Included
+--------------
+
+### Development Tooling Configuration
+
+- tsconfig.json
+- .eslintrc.js
+- .prettierrc.js
+
+### Common Libraries With Boilerplate
+
+- [Formik](https://formik.org/)
+- [React Navigation](https://reactnavigation.org/)
+- [yup](https://github.com/jquense/yup)
+
+### Styling
+
+- [React Native Typescript Styles](https://github.com/thoughtbot/react-native-typescript-styles)
+- [React Native Vector Icons](https://github.com/oblador/react-native-vector-icons) with Feather Icons
+
+### Boilerplate Components
+
+- Basic Authentication Forms
+- Tab Navigation
+- TextField
+
+Contributing
+------------
+
+Please see [CONTRIBUTING.md](https://github.com/thoughtbot/react-native-liftoff/blob/master/CONTRIBUTING.md).
+
+React Native Liftoff was originally written by Devin Jameson and Anthony Moffa and is maintained by thoughtbot.
+Many improvements and bugfixes were contributed by the [open source
+community](https://github.com/thoughtbot/react-native-liftoff/graphs/contributors).
+
+License
+-------
+
+react-native-liftoff is Copyright © 2021 thoughtbot. It is free software, and
+may be redistributed under the terms specified in the [LICENSE] file.
+
+[LICENSE]: https://github.com/thoughtbot/react-native-liftoff/blob/master/LICENSE
+
+
+About thoughtbot
+----------------
+
+![thoughtbot](https://thoughtbot.com/brand_assets/93:44.svg)
+
+react-native-liftoff is maintained and funded by thoughtbot, inc.
+The names and logos for thoughtbot are trademarks of thoughtbot, inc.
+
+We love open source software!
+See [our other projects][community] or
+[hire us][hire] to design, develop, and grow your product.
+
+[community]: https://thoughtbot.com/community?utm_source=github
+[hire]: https://thoughtbot.com/hire-us?utm_source=github
+
+Should we say anything about this being inspired by [Ignite](https://github.com/infinitered/ignite)?
+
+Also should we mention
+


### PR DESCRIPTION
Why:
For thoughtbot opensource projects we want to have information about our
license agreement and how contribution is managed.

This commit:
Updates the readme to include information thoughtbot, our license, and
contributing.